### PR TITLE
Undoes object labels for Buffers; not quite sure what the problem is.

### DIFF
--- a/pkzo/opengl.cpp
+++ b/pkzo/opengl.cpp
@@ -198,11 +198,12 @@ namespace pkzo::opengl
         }
     }
 
-    Buffer::Buffer(const void* data, const uint _size, BufferUsage usage)
+    Buffer::Buffer(const void* data, const uint _size, BufferUsage usage, const std::string_view label)
     : size(_size)
     {
          glCreateBuffers(1, &id);
          glNamedBufferData(id, size, data, to_underlying(usage));
+         //glObjectLabel(id, GL_BUFFER, label.size(), label.data());
          check_glerror();
     }
 
@@ -421,7 +422,7 @@ namespace pkzo::opengl
     VertexBuffer::VertexBuffer(const std::string_view label)
     {
         glGenVertexArrays(1, &id);
-        glObjectLabel(GL_VERTEX_ARRAY, id, static_cast<GLsizei>(label.size()), label.data());
+        //glObjectLabel(GL_VERTEX_ARRAY, id, static_cast<GLsizei>(label.size()), label.data());
         check_glerror();
     }
 

--- a/pkzo/opengl.h
+++ b/pkzo/opengl.h
@@ -105,7 +105,7 @@ namespace pkzo::opengl
     class PKZO_EXPORT Buffer
     {
     public:
-        Buffer(const void* data, const uint size, BufferUsage usage = BufferUsage::STATIC_DRAW);
+        Buffer(const void* data, const uint size, BufferUsage usage = BufferUsage::STATIC_DRAW, const std::string_view label = "unnamed");
         ~Buffer();
 
         uint get_id() const noexcept;


### PR DESCRIPTION
### Description of Change

Undoes object labels for Buffers; not quite sure what the problem is.

### Checklist

Please check the appropriate fields:

- [ ] The pull request fully implements one feature or bug.
- [x] All configurations build on my machine.
- [x] All tests run on my machine.
- [ ] All API docs where updated.
- [ ] The ChangeLog.md was updated.
- [ ] A reference image or threshold was changed.

### Notes


