### PR TITLE
Refactor Mesh class to improve data locality with packed vertices

### DIFF
--- a/pkzo/Mesh.cpp
+++ b/pkzo/Mesh.cpp
@@ -56,10 +56,7 @@ namespace pkzo
 
     void Mesh::add_vertex(const glm::vec3& vertex, const glm::vec3& normal, const glm::vec3& tangent, const glm::vec2& texcoord)
     {
-        vertexes.push_back(vertex);
-        normals.push_back(normal);
-        tangents.push_back(tangent);
-        texcoords.push_back(texcoord);
+        vertices.emplace_back(vertex, normal, tangent, texcoord);
     }
 
     void Mesh::add_triangle(uint a, uint b, uint c)
@@ -69,7 +66,7 @@ namespace pkzo
 
     uint Mesh::get_vertex_count() const noexcept
     {
-        return static_cast<uint>(vertexes.size());
+        return static_cast<uint>(vertices.size());
     }
 
     uint Mesh::get_triangle_count() const noexcept
@@ -85,10 +82,7 @@ namespace pkzo
         }
 
         vertex_buffer = std::make_shared<opengl::VertexBuffer>();
-        vertex_buffer->upload_values(vertexes);
-        vertex_buffer->upload_values(normals);
-        vertex_buffer->upload_values(tangents);
-        vertex_buffer->upload_values(texcoords);
+        vertex_buffer->upload_values({3, 3, 3, 2}, static_cast<uint>(vertices.size()), glm::value_ptr(vertices[0].vertex));
         vertex_buffer->upload_indexes(triangles);
     }
 

--- a/pkzo/Mesh.h
+++ b/pkzo/Mesh.h
@@ -81,13 +81,15 @@ namespace pkzo
         void draw();
 
     private:
-        // TODO: check if glm::vec4 provides better performance
-        std::vector<glm::vec3>         vertexes;
-        std::vector<glm::vec3>         normals;
-        std::vector<glm::vec3>         tangents;
-        std::vector<glm::vec2>         texcoords;
-
-        std::vector<glm::uvec3>        triangles;
+        struct Vertex
+        {
+            glm::vec3 vertex;
+            glm::vec3 normal;
+            glm::vec3 tangent;
+            glm::vec2 texcoord;
+        };
+        std::vector<Vertex>     vertices;
+        std::vector<glm::uvec3> triangles;
 
         std::shared_ptr<opengl::VertexBuffer> vertex_buffer;
     };

--- a/pkzo/opengl.cpp
+++ b/pkzo/opengl.cpp
@@ -22,6 +22,7 @@
 #include "opengl.h"
 
 #include <array>
+#include <numeric>
 
 #include "debug.h"
 #include "utils.h"
@@ -501,6 +502,25 @@ namespace pkzo::opengl
         glVertexAttribPointer(static_cast<GLuint>(buffers.size()), stride, GL_FLOAT, GL_FALSE, 0, nullptr);
         check_glerror();
 
+        buffers.push_back(buffer);
+    }
+
+    void VertexBuffer::upload_values(std::vector<glm::uint> elements, glm::uint count, const float* data) noexcept
+    {
+        glm::uint total_size = std::accumulate(elements.begin(), elements.end(), 0u);
+        auto buffer = std::make_shared<Buffer>(data, static_cast<uint>(count * total_size * sizeof(float)));
+
+        glBindVertexArray(id);
+        glBindBuffer(GL_ARRAY_BUFFER, buffer->get_id());
+
+        uint offset = 0;
+        for (uint i = 0; i < elements.size(); ++i)
+        {
+            glEnableVertexAttribArray(static_cast<GLuint>(buffers.size() + i));
+            glVertexAttribPointer(static_cast<GLuint>(buffers.size() + i), elements[i], GL_FLOAT, GL_FALSE, total_size * sizeof(float), reinterpret_cast<void*>(offset * sizeof(float)));
+            offset += elements[i];
+        }
+        check_glerror();
         buffers.push_back(buffer);
     }
 

--- a/pkzo/opengl.h
+++ b/pkzo/opengl.h
@@ -205,7 +205,8 @@ namespace pkzo::opengl
         uint get_id() const noexcept;
         uint get_size() const noexcept;
 
-        void upload_values(uint stride, uint count, const float* data) noexcept;
+        void upload_values(uint elements, uint count, const float* data) noexcept;
+        void upload_values(std::vector<glm::uint> elements, glm::uint count, const float* data) noexcept;
 
         template <int N, qualifier Q>
         void upload_values(const std::vector<vec<N, float, Q>>& values) noexcept;


### PR DESCRIPTION
### Description of Change

Refactor Mesh class to improve data locality with packed vertices

- Introduced an inner struct, Vertex, in the Mesh class to hold vertex attributes.
- Packed vertex, normal, tangent, and texcoord into a single std::vector<Vertex>.

This change aims to improve cache locality and reduce the OpenGL API calls needed for data upload.

### Checklist

Please check the appropriate fields:

- [x] The pull request fully implements one feature or bug.
- [x] All configurations build on my machine.
- [x] All tests run on my machine.
- [ ] All API docs where updated.
- [ ] The ChangeLog.md was updated.
- [ ] A reference image or threshold was changed.

### Notes

