### PR TITLE
Add CMake build and install files for pkzo libraries

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -35,16 +35,17 @@ jobs:
           vcpkgGitURL: https://github.com/rioki/vcpkg.git
           vcpkgGitCommitId: 62159a45e18f3a9ac0548628dcaf74fcb60c6ff9
 
-      - name: Configure
-        run: >-
-          cmake -S . -B build
-          -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
-          -DCMAKE_TOOLCHAIN_FILE=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}/scripts/buildsystems/vcpkg.cmake
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
-          -A ${{ matrix.platform }}
-
-      - name: Build
-        run: cmake --build build --config ${{ matrix.configuration }}
-
-      - name: Install
-        run: cmake --install build --config ${{ matrix.configuration }} --prefix install
+      - name: Configure + Build + Install
+        uses: lukka/run-cmake@v10
+        with:
+          cmakeListsTxtPath: ${{ github.workspace }}
+          cmakeBuildDirectory: ${{ github.workspace }}/build
+          cmakeAppendedArgs: >-
+            -A ${{ matrix.platform }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
+            -DCMAKE_TOOLCHAIN_FILE=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}/scripts/buildsystems/vcpkg.cmake
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+          buildWithCMakeArgs: >-
+            --config ${{ matrix.configuration }}
+            --target install
+            --prefix install

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -14,7 +14,11 @@ jobs:
     strategy:
       matrix:
         configuration: [Release, Debug]
-        triplet: [x64-windows]
+        include:
+          - triplet: x86-windows
+            platform: Win32
+          - triplet: x64-windows
+            platform: x64
     runs-on: windows-latest
 
     env:
@@ -37,6 +41,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
           -DCMAKE_TOOLCHAIN_FILE=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}/scripts/buildsystems/vcpkg.cmake
           -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+          -A ${{ matrix.platform }}
 
       - name: Build
         run: cmake --build build --config ${{ matrix.configuration }}

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -1,0 +1,45 @@
+name: CMake
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Release, Debug]
+        triplet: [x64-windows]
+    runs-on: windows-latest
+
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore from cache and install vcpkg
+        id: runvcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitURL: https://github.com/rioki/vcpkg.git
+          vcpkgGitCommitId: 62159a45e18f3a9ac0548628dcaf74fcb60c6ff9
+
+      - name: Configure
+        run: >-
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
+          -DCMAKE_TOOLCHAIN_FILE=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+
+      - name: Build
+        run: cmake --build build --config ${{ matrix.configuration }}
+
+      - name: Install
+        run: cmake --install build --config ${{ matrix.configuration }} --prefix install

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -32,7 +32,7 @@ jobs:
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitURL: https://github.com/rioki/vcpkg.git
-        vcpkgGitCommitId: a23f2d7dd1e8af66a04f686599e297a594d21f56
+        vcpkgGitCommitId: 62159a45e18f3a9ac0548628dcaf74fcb60c6ff9
     - name: Integrate vcpkg 
       working-directory: ${{steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT}}
       run: vcpkg.exe integrate install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.21)
 
 project(pkzo VERSION 0.1.0 LANGUAGES CXX)
 
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -23,7 +23,6 @@ find_package(fkYAML CONFIG REQUIRED)
 find_package(rsig CONFIG REQUIRED)
 find_package(FreeImage CONFIG REQUIRED)
 
-
 function(pkzo_link_first_available target)
   set(options)
   set(one_value_args)
@@ -40,10 +39,10 @@ function(pkzo_link_first_available target)
   message(FATAL_ERROR "Could not find any usable target for ${target}. Tried: ${ARG_CANDIDATES}")
 endfunction()
 
-function(pkzo_install_headers target source_dir)
+function(pkzo_install_headers source_dir install_subdir)
   install(
     DIRECTORY "${source_dir}/"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${target}"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${install_subdir}"
     FILES_MATCHING
       PATTERN "*.h"
   )
@@ -79,6 +78,7 @@ add_library(pkzo ${PKZO_SOURCES})
 add_library(pkzo::pkzo ALIAS pkzo)
 
 target_compile_definitions(pkzo PRIVATE BUILD_PKZO STRCONV_DLL BUILD_STRCONV)
+
 target_include_directories(pkzo
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -94,12 +94,16 @@ target_link_libraries(pkzo
 
 pkzo_link_first_available(pkzo CANDIDATES magic_enum::magic_enum magic_enum::magic_enum-header-only)
 pkzo_link_first_available(pkzo CANDIDATES tinyformat::tinyformat tinyformat::tinyformat-header-only)
-pkzo_link_first_available(pkzo CANDIDATES fkYAML::fkYAML fkYAML::fkYAML-header-only)
+pkzo_link_first_available(pkzo CANDIDATES fkYAML::fkYAML fkyaml::fkyaml fkYAML::fkYAML-header-only)
 pkzo_link_first_available(pkzo CANDIDATES rsig::rsig unofficial::rsig::rsig)
 pkzo_link_first_available(pkzo CANDIDATES FreeImage::FreeImage freeimage::FreeImage unofficial::freeimage::FreeImage)
 pkzo_link_first_available(pkzo CANDIDATES Freetype::Freetype freetype)
 pkzo_link_first_available(pkzo CANDIDATES GLEW::GLEW GLEW::glew unofficial::glew::glew)
 pkzo_link_first_available(pkzo CANDIDATES SDL3::SDL3 SDL3::SDL3-static)
+
+if(WIN32)
+  target_link_libraries(pkzo PRIVATE dbghelp)
+endif()
 
 set(PKZO2D_SOURCES
   pkzo2d/Group.cpp
@@ -182,11 +186,8 @@ pkzo_link_first_available(pkzo3d CANDIDATES Bullet::BulletDynamics BulletDynamic
 pkzo_link_first_available(pkzo3d CANDIDATES Bullet::BulletCollision BulletCollision)
 pkzo_link_first_available(pkzo3d CANDIDATES Bullet::LinearMath LinearMath)
 
-if(WIN32)
-  target_link_libraries(pkzo PRIVATE dbghelp)
-endif()
-
-install(TARGETS pkzo pkzo2d pkzo3d
+install(
+  TARGETS pkzo pkzo2d pkzo3d
   EXPORT pkzoTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,223 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(pkzo VERSION 0.1.0 LANGUAGES CXX)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(assimp CONFIG REQUIRED)
+find_package(Bullet CONFIG REQUIRED)
+find_package(freetype CONFIG REQUIRED)
+find_package(glm CONFIG REQUIRED)
+find_package(GLEW CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(SDL3 CONFIG REQUIRED)
+find_package(Iconv REQUIRED)
+find_package(magic_enum CONFIG REQUIRED)
+find_package(tinyformat CONFIG REQUIRED)
+find_package(fkYAML CONFIG REQUIRED)
+find_package(rsig CONFIG REQUIRED)
+find_package(FreeImage CONFIG REQUIRED)
+
+
+function(pkzo_link_first_available target)
+  set(options)
+  set(one_value_args)
+  set(multi_value_args CANDIDATES)
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "${options}" "${one_value_args}" "${multi_value_args}")
+
+  foreach(candidate IN LISTS ARG_CANDIDATES)
+    if(TARGET "${candidate}")
+      target_link_libraries(${target} PUBLIC "${candidate}")
+      return()
+    endif()
+  endforeach()
+
+  message(FATAL_ERROR "Could not find any usable target for ${target}. Tried: ${ARG_CANDIDATES}")
+endfunction()
+
+function(pkzo_install_headers target source_dir)
+  install(
+    DIRECTORY "${source_dir}/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${target}"
+    FILES_MATCHING
+      PATTERN "*.h"
+  )
+endfunction()
+
+set(PKZO_SOURCES
+  pkzo/Bounds.cpp
+  pkzo/CubeMap.cpp
+  pkzo/debug.cpp
+  pkzo/events.cpp
+  pkzo/Font.cpp
+  pkzo/FreeImageTexture.cpp
+  pkzo/FreeTypeFont.cpp
+  pkzo/GraphicContext.cpp
+  pkzo/Keyboard.cpp
+  pkzo/MemoryMesh.cpp
+  pkzo/Mesh.cpp
+  pkzo/Mouse.cpp
+  pkzo/OpenGLBuffer.cpp
+  pkzo/OpenGLCubeMap.cpp
+  pkzo/OpenGLFrameBuffer.cpp
+  pkzo/OpenGLGraphicContext.cpp
+  pkzo/OpenGLMesh.cpp
+  pkzo/OpenGLShader.cpp
+  pkzo/OpenGLTexture.cpp
+  pkzo/SdlSentry.cpp
+  pkzo/strconv.cpp
+  pkzo/Texture.cpp
+  pkzo/Window.cpp
+)
+
+add_library(pkzo ${PKZO_SOURCES})
+add_library(pkzo::pkzo ALIAS pkzo)
+
+target_compile_definitions(pkzo PRIVATE BUILD_PKZO STRCONV_DLL BUILD_STRCONV)
+target_include_directories(pkzo
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(pkzo
+  PUBLIC
+    glm::glm
+    nlohmann_json::nlohmann_json
+    Iconv::Iconv
+)
+
+pkzo_link_first_available(pkzo CANDIDATES magic_enum::magic_enum magic_enum::magic_enum-header-only)
+pkzo_link_first_available(pkzo CANDIDATES tinyformat::tinyformat tinyformat::tinyformat-header-only)
+pkzo_link_first_available(pkzo CANDIDATES fkYAML::fkYAML fkYAML::fkYAML-header-only)
+pkzo_link_first_available(pkzo CANDIDATES rsig::rsig unofficial::rsig::rsig)
+pkzo_link_first_available(pkzo CANDIDATES FreeImage::FreeImage freeimage::FreeImage unofficial::freeimage::FreeImage)
+pkzo_link_first_available(pkzo CANDIDATES Freetype::Freetype freetype)
+pkzo_link_first_available(pkzo CANDIDATES GLEW::GLEW GLEW::glew unofficial::glew::glew)
+pkzo_link_first_available(pkzo CANDIDATES SDL3::SDL3 SDL3::SDL3-static)
+
+set(PKZO2D_SOURCES
+  pkzo2d/Group.cpp
+  pkzo2d/HitArea.cpp
+  pkzo2d/Node.cpp
+  pkzo2d/Rectangle.cpp
+  pkzo2d/Renderer.cpp
+  pkzo2d/Screen.cpp
+  pkzo2d/Shape.cpp
+  pkzo2d/Text.cpp
+)
+
+add_library(pkzo2d ${PKZO2D_SOURCES})
+add_library(pkzo::pkzo2d ALIAS pkzo2d)
+
+target_compile_definitions(pkzo2d
+  PRIVATE
+    BUILD_PKZO2D
+    SOLUTION_DIR="${CMAKE_SOURCE_DIR}/"
+    PROJECT_DIR="${CMAKE_SOURCE_DIR}/pkzo2d/"
+)
+
+target_include_directories(pkzo2d
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(pkzo2d PUBLIC pkzo)
+
+set(PKZO3D_SOURCES
+  pkzo3d/AmbientLight.cpp
+  pkzo3d/Body.cpp
+  pkzo3d/BoxGeometry.cpp
+  pkzo3d/BulletPhysicsSimulation.cpp
+  pkzo3d/Camera.cpp
+  pkzo3d/CylinderGeometry.cpp
+  pkzo3d/DirectionalLight.cpp
+  pkzo3d/Geometry.cpp
+  pkzo3d/Ghost.cpp
+  pkzo3d/Group.cpp
+  pkzo3d/Light.cpp
+  pkzo3d/Material.cpp
+  pkzo3d/MeshGeometry.cpp
+  pkzo3d/Model.cpp
+  pkzo3d/ModelInstance.cpp
+  pkzo3d/Node.cpp
+  pkzo3d/PhysicsSimulation.cpp
+  pkzo3d/PointLight.cpp
+  pkzo3d/Renderer.cpp
+  pkzo3d/Scene.cpp
+  pkzo3d/SkyBox.cpp
+  pkzo3d/SphereGeometry.cpp
+  pkzo3d/SpotLight.cpp
+)
+
+add_library(pkzo3d ${PKZO3D_SOURCES})
+add_library(pkzo::pkzo3d ALIAS pkzo3d)
+
+target_compile_definitions(pkzo3d
+  PRIVATE
+    BUILD_PKZO3D
+    SOLUTION_DIR="${CMAKE_SOURCE_DIR}/"
+    PROJECT_DIR="${CMAKE_SOURCE_DIR}/pkzo3d/"
+)
+
+target_include_directories(pkzo3d
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(pkzo3d
+  PUBLIC
+    pkzo
+    assimp::assimp
+)
+
+pkzo_link_first_available(pkzo3d CANDIDATES Bullet::BulletDynamics BulletDynamics)
+pkzo_link_first_available(pkzo3d CANDIDATES Bullet::BulletCollision BulletCollision)
+pkzo_link_first_available(pkzo3d CANDIDATES Bullet::LinearMath LinearMath)
+
+if(WIN32)
+  target_link_libraries(pkzo PRIVATE dbghelp)
+endif()
+
+install(TARGETS pkzo pkzo2d pkzo3d
+  EXPORT pkzoTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+pkzo_install_headers(pkzo pkzo)
+pkzo_install_headers(pkzo2d pkzo2d)
+pkzo_install_headers(pkzo3d pkzo3d)
+
+install(
+  EXPORT pkzoTargets
+  NAMESPACE pkzo::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pkzo
+)
+
+configure_package_config_file(
+  cmake/pkzoConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/pkzoConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pkzo
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/pkzoConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/pkzoConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/pkzoConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pkzo
+)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,77 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ninja-base",
+      "hidden": true,
+      "displayName": "Ninja Multi-Config Base",
+      "description": "Base configure preset using vcpkg toolchain",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        },
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/builds/install/${presetName}"
+      }
+    },
+    {
+      "name": "ninja-x64-windows",
+      "inherits": [
+        "ninja-base"
+      ],
+      "displayName": "Ninja Multi-Config x64-windows",
+      "description": "Configure with vcpkg x64-windows triplet",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows"
+      }
+    },
+    {
+      "name": "ninja-x86-windows",
+      "inherits": [
+        "ninja-base"
+      ],
+      "displayName": "Ninja Multi-Config x86-windows",
+      "description": "Configure with vcpkg x86-windows triplet",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x86-windows"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ninja-x64-debug",
+      "configurePreset": "ninja-x64-windows",
+      "displayName": "Build x64 Debug",
+      "description": "Build with Ninja Multi-Config (x64/Debug)",
+      "configuration": "Debug"
+    },
+    {
+      "name": "ninja-x64-release",
+      "configurePreset": "ninja-x64-windows",
+      "displayName": "Build x64 Release",
+      "description": "Build with Ninja Multi-Config (x64/Release)",
+      "configuration": "Release"
+    },
+    {
+      "name": "ninja-x86-debug",
+      "configurePreset": "ninja-x86-windows",
+      "displayName": "Build x86 Debug",
+      "description": "Build with Ninja Multi-Config (x86/Debug)",
+      "configuration": "Debug"
+    },
+    {
+      "name": "ninja-x86-release",
+      "configurePreset": "ninja-x86-windows",
+      "displayName": "Build x86 Release",
+      "description": "Build with Ninja Multi-Config (x86/Release)",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/cmake/pkzoConfig.cmake.in
+++ b/cmake/pkzoConfig.cmake.in
@@ -1,0 +1,19 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(assimp CONFIG)
+find_dependency(Bullet CONFIG)
+find_dependency(freetype CONFIG)
+find_dependency(glm CONFIG)
+find_dependency(GLEW CONFIG)
+find_dependency(nlohmann_json CONFIG)
+find_dependency(SDL3 CONFIG)
+find_dependency(Iconv)
+find_dependency(magic_enum CONFIG)
+find_dependency(tinyformat CONFIG)
+find_dependency(fkYAML CONFIG)
+find_dependency(rsig CONFIG)
+find_dependency(FreeImage CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/pkzoTargets.cmake")

--- a/cmake/pkzoConfig.cmake.in
+++ b/cmake/pkzoConfig.cmake.in
@@ -14,6 +14,14 @@ find_dependency(magic_enum CONFIG)
 find_dependency(tinyformat CONFIG)
 find_dependency(fkYAML CONFIG)
 find_dependency(rsig CONFIG)
-find_dependency(FreeImage CONFIG)
+
+if(NOT TARGET FreeImage::FreeImage AND NOT TARGET freeimage::FreeImage AND NOT TARGET unofficial::freeimage::FreeImage)
+  find_dependency(FreeImage CONFIG)
+endif()
+
+if(NOT TARGET FreeImage::FreeImage AND NOT TARGET freeimage::FreeImage AND NOT TARGET unofficial::freeimage::FreeImage)
+  find_dependency(unofficial-freeimage CONFIG)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/pkzoTargets.cmake")
+check_required_components(pkzo)


### PR DESCRIPTION
### Motivation
- Provide a proper CMake build so `pkzo` can be packaged by vcpkg and consumed via `find_package(pkzo)`, while only building and deploying the library targets and not the examples.

### Description
- Add top-level `CMakeLists.txt` that defines `pkzo`, `pkzo2d`, and `pkzo3d` targets with explicit source lists and public include/install interfaces.
- Add dependency discovery (`find_package`) for assimp, Bullet, FreeImage, FreeType, SDL3, GLEW, glm, nlohmann_json, Iconv and other deps, and wire those to the targets.
- Implement `pkzo_link_first_available` helper to try multiple imported-target name variants (improves vcpkg compatibility) and use it to pick the correct imported targets for header-only or vendor-named packages.
- Add install/export rules and header installation via an `pkzo_install_headers` helper, and add `cmake/pkzoConfig.cmake.in` so downstream `find_package(pkzo)` forwards dependencies and imports exported targets.

### Testing
- Ran `cmake -S . -B build` which produced syntax warnings (quoting of compile-def strings) that were addressed in the patch, and then re-ran configuration.
- Ran `cmake -S . -B /tmp/pkzo-cmake-check` to verify configure; configure failed because required package config files (for example `assimp`) are not available in `CMAKE_PREFIX_PATH` in this environment, so configuration could not complete.
- No compilation unit was built here because configure did not complete due to missing dependency package configs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46b01a4808326a6105a003947ee4b)